### PR TITLE
Set _ColReorder_iOrigCol only once

### DIFF
--- a/ColReorderWithResize.js
+++ b/ColReorderWithResize.js
@@ -765,7 +765,9 @@ $.extend( ColReorder.prototype, {
             }
 
             /* Mark the original column order for later reference */
-            this.s.dt.aoColumns[i]._ColReorder_iOrigCol = i;
+            if(this.s.dt.aoColumns[i]._ColReorder_iOrigCol === undefined){
+                this.s.dt.aoColumns[i]._ColReorder_iOrigCol = i;
+            }
         }
 
         /* State saving */


### PR DESCRIPTION
If the columns are dragged the _ColReorder_iOrigCol is gets updated, this makes that the values are resetted and the original value in _ColReorder_iOrigCol is lost.

This problem occured when using the StateSave functionality the ColReorder property of the state was always sequential like [1,2,3,4, etc].