### PR TITLE
Remove fnConstruct in mouseUp

### DIFF
--- a/ColReorderWithResize.js
+++ b/ColReorderWithResize.js
@@ -1315,9 +1315,6 @@ $.extend( ColReorder.prototype, {
                 this.s.dt.oInstance.fnAdjustColumnSizing( false );
             }
 
-            // Re-initialize so as to register the new column order (otherwise the events remain bound to the original column indices).
-            this._fnConstruct();
-
             this.s.dt.oInstance.trigger('column-reorder.dt.mouseup', [ this.s.dt ] );
 
             /* Save the state */


### PR DESCRIPTION
The fnConstruct function in mouseUp caused some trouble when a state was loaded, columns where moved randomly. After it was removed I didn't notice any problems. 

It also resets the _ColReorder_iOrigCol which caused some problems when saving the state (the col Reorder was always sequential like [1,2,3,4 etc.]